### PR TITLE
Add `workflow_dispatch` to enable manual running of the workflow on initial fork

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Workflows are not run on initial fork of the repository. Adding `workflow_dispatch` to the `deploy.yml` workflow allows manually running the workflow on demand. This would also help in cases where the workflow failed due to a secrets configuration error, as otherwise you must wait for a change to the repo to be made before the workflow is run again.
Resolves #48 